### PR TITLE
Handle open section better

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -254,6 +254,12 @@ namespace
             // Open section if the grammar lets us but only push to indent stack if we go further down in the stack
             if (valid_symbols[VIRTUAL_OPEN_SECTION] && !lexer->eof(lexer))
             {
+                // If there is a comment, don't proceed, we don't
+                // need to check more as case branches/let variables can't start with a `-`
+                if (lexer->lookahead == '-')
+                {
+                    return false;
+                }
                 indent_length_stack.push_back(lexer->get_column(lexer)); // This needs a `!lexer->eof(lexer)` check or it will get stuck
                 lexer->result_symbol = VIRTUAL_OPEN_SECTION;
                 return true;

--- a/test/corpus/case.txt
+++ b/test/corpus/case.txt
@@ -1203,3 +1203,77 @@ flipBy how (Plane (width, height) _ as plane) =
                   (value_expr
                     (value_qid
                       (lower_case_identifier))))))))))))
+
+================================================================================
+Case with of followed by comment
+================================================================================
+
+module Test exposing (..)
+type Maybe a = Just a | Nothing
+func result =
+    case result of
+    --^
+        Nothing ->
+            ""
+        Just (Just a) ->
+            a
+
+--------------------------------------------------------------------------------
+
+(file
+  (module_declaration
+    (module)
+    (upper_case_qid
+      (upper_case_identifier))
+    (exposing_list
+      (exposing)
+      (double_dot)))
+  (type_declaration
+    (type)
+    (upper_case_identifier)
+    (lower_type_name
+      (lower_case_identifier))
+    (eq)
+    (union_variant
+      (upper_case_identifier)
+      (type_variable
+        (lower_case_identifier)))
+    (union_variant
+      (upper_case_identifier)))
+  (value_declaration
+    (function_declaration_left
+      (lower_case_identifier)
+      (lower_pattern
+        (lower_case_identifier)))
+    (eq)
+    (case_of_expr
+      (case)
+      (value_expr
+        (value_qid
+          (lower_case_identifier)))
+      (of)
+      (line_comment)
+      (case_of_branch
+        (pattern
+          (union_pattern
+            (upper_case_qid
+              (upper_case_identifier))))
+        (arrow)
+        (string_constant_expr
+          (open_quote)
+          (close_quote)))
+      (case_of_branch
+        (pattern
+          (union_pattern
+            (upper_case_qid
+              (upper_case_identifier))
+            (pattern
+              (union_pattern
+                (upper_case_qid
+                  (upper_case_identifier))
+                (lower_pattern
+                  (lower_case_identifier))))))
+        (arrow)
+        (value_expr
+          (value_qid
+            (lower_case_identifier)))))))

--- a/test/corpus/let.txt
+++ b/test/corpus/let.txt
@@ -935,3 +935,34 @@ oops =
       (value_expr
         (value_qid
           (lower_case_identifier))))))
+
+================================================================================
+Let with line comment at start
+================================================================================
+
+oops =
+    let
+        -- evil comment
+        x =
+            1
+    in
+    x
+
+--------------------------------------------------------------------------------
+
+(file
+  (value_declaration
+    (function_declaration_left
+      (lower_case_identifier))
+    (eq)
+    (let_in_expr
+      (line_comment)
+      (value_declaration
+        (function_declaration_left
+          (lower_case_identifier))
+        (eq)
+        (number_constant_expr
+          (number_literal)))
+      (value_expr
+        (value_qid
+          (lower_case_identifier))))))


### PR DESCRIPTION
When there was a comment right after the open section,
we would end up with the wrong indentation in our stack