### PR TITLE
Use byte offset for indent_length

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -182,16 +182,15 @@ namespace
                 {
                     skip(lexer);
                     has_newline = true;
-                    indent_length = 0;
                     while (true)
                     {
                         if (lexer->lookahead == ' ')
                         {
-                            indent_length++;
                             skip(lexer);
                         }
                         else
                         {
+                            indent_length = lexer->get_column(lexer);
                             break;
                         }
                     }


### PR DESCRIPTION
Now that get_column is returning the offset byte count, we need
to compare it with a byte based offset too.

Somehow this only affected the web-tree-sitter bindings.