### PR TITLE
Relax tree-sitter version bounds to include 0.20.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ version = "5.3.7"
 
 
 [dependencies]
-tree-sitter = "0.19.5"
+tree-sitter = ">= 0.19.5, < 0.21"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
Hi there! I've been happily using the rust crate provided by this repo for the last month or so. I've noticed that the version of tree-sitter pinned here (0.19.5) is a bit behind the latest release (0.20.1). This PR relaxes the version bounds to include the old 0.19.5 and 0.20.x both.

Based on my own testing with version 0.20.1 this doesn't result in any problems.