### PR TITLE
SPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build
 .idea
 .vscode/ipch
 target/
+/.build/
 
 # Examples generated during automated tests
 examples/**

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,43 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterElm",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterElm", targets: ["TreeSitterElm"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterElm",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.toml",
+                    "docs",
+                    "examples",
+                    "grammar.js",
+                    "HOW_TO_RELEASE.md",
+                    "index.d.ts",
+                    "LICENSE.md",
+                    "package.json",
+                    "README.md",
+                    "script",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                    "test",
+                    "tsconfig.json",
+                ],
+                sources: [
+                    "src/parser.c",
+                    "src/scanner.cc",
+                ],
+                resources: [
+                    .copy("queries")
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/TreeSitterElm/elm.h
+++ b/bindings/swift/TreeSitterElm/elm.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_ELM_H_
+#define TREE_SITTER_ELM_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_elm();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_ELM_H_


### PR DESCRIPTION
This adds Swift bindings and Swift Package Manager (SPM) support. I maintain the tree-sitter Swift binding here https://github.com/chimeHQ/SwiftTreeSitter

Here are some examples of other PRs:

https://github.com/tree-sitter/tree-sitter-go/pull/79
https://github.com/tree-sitter/tree-sitter-c/pull/105
https://github.com/tree-sitter/tree-sitter-haskell/pull/91

These are manually created. They should not ever impact the parser. Changes that require the use of a cpp scanner, which some parsers need, would require an update. The exclude patterns are pretty safe to get out of sync. They can, in some circumstances, generate warnings for Swift users. But, it's really minor.