### PR TITLE
update tree-sitter peerDependency to ^0.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tree-sitter-cli": "^0.25.3"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.21.1"
+    "tree-sitter": "^0.25"
   },
   "peerDependenciesMeta": {
     "tree-sitter": {


### PR DESCRIPTION
fix for #186 (It should removes the need of `npm install --force` on user side)